### PR TITLE
Ignore application.properties

### DIFF
--- a/ignore.txt
+++ b/ignore.txt
@@ -46,3 +46,4 @@ RepositoryManager.properties
 swift.properties
 UserAttributeRoleProvider.properties
 content_type_classes.properties
+application.properties


### PR DESCRIPTION
Rubrics is out of the build so far, because of its different technology stack, so this files must be ignored by transifex, because is mixing translation properties with configuration properties.

https://github.com/sakaiproject/sakai/blob/master/rubrics/services/src/main/resources/application.properties
